### PR TITLE
feat: add interactive riemann integral explorer

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,54 +1,69 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Riemann Integral Visualizer</title>
-  <link rel="stylesheet" href="style.css">
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Riemann Integral Explorer</title>
+  <link rel="stylesheet" href="style.css" />
+  <script defer src="script.js"></script>
 </head>
 <body>
-  <h1>Riemann Integral Visualizer</h1>
-
-  <div class="controls">
-    <label>
-      Function f(x):
-      <input type="text" id="funcInput" value="Math.sin(x) + 1.5">
-    </label>
-    <label>
-      Interval a:
-      <input type="number" id="aInput" value="0" step="0.1">
-    </label>
-    <label>
-      Interval b:
-      <input type="number" id="bInput" value="Math.PI" step="0.1">
-    </label>
-    <label>
-      Partitions n:
-      <input type="number" id="nInput" value="10" min="1" step="1">
-    </label>
-    <label>
-      <input type="checkbox" id="showUpper" checked>
-      Show Upper Sum
-    </label>
-    <label>
-      <input type="checkbox" id="showLower" checked>
-      Show Lower Sum
-    </label>
-  </div>
-
-  <div class="graph-container">
-    <canvas id="graphCanvas"></canvas>
-  </div>
-
-  <div class="sums-panel">
-    <h2>Riemann Sums</h2>
-    <p>Left Sum: <span id="leftSum">0</span></p>
-    <p>Right Sum: <span id="rightSum">0</span></p>
-    <p>Midpoint Sum: <span id="midSum">0</span></p>
-    <p>Upper Sum: <span id="upperSum">0</span></p>
-    <p>Lower Sum: <span id="lowerSum">0</span></p>
-  </div>
-
-  <script src="script.js"></script>
+  <header class="app-header">
+    <h1>Riemann Integral Explorer</h1>
+    <button id="themeToggle" aria-label="Toggle light/dark theme">🌙</button>
+  </header>
+  <div id="alert" class="alert" role="alert" aria-live="polite"></div>
+  <main class="layout">
+    <section class="controls" aria-label="Controls">
+      <div class="field">
+        <label for="funcInput">f(x)</label>
+        <input id="funcInput" type="text" value="Math.sin(x)+1.5" aria-describedby="formulaHelp" />
+        <small id="formulaHelp">Use Math.* functions, e.g. <code>Math.sin(x)</code></small>
+      </div>
+      <div class="field">
+        <label for="aInput">a</label>
+        <input id="aInput" type="number" step="0.1" value="0" />
+      </div>
+      <div class="field">
+        <label for="bInput">b</label>
+        <input id="bInput" type="number" step="0.1" value="3.14159" />
+      </div>
+      <div class="field">
+        <label for="nInput">Partitions: <span id="nLabel">10</span></label>
+        <input id="nInput" type="range" min="1" max="500" value="10" />
+      </div>
+      <fieldset class="methods">
+        <legend>Methods</legend>
+        <label><input type="checkbox" value="left" checked />Left</label>
+        <label><input type="checkbox" value="right" checked />Right</label>
+        <label><input type="checkbox" value="mid" checked />Midpoint</label>
+        <label><input type="checkbox" value="upper" checked />Upper</label>
+        <label><input type="checkbox" value="lower" checked />Lower</label>
+        <label><input type="checkbox" value="trap" />Trapezoidal</label>
+        <label><input type="checkbox" value="simp" />Simpson</label>
+        <label class="compare"><input id="compareAll" type="checkbox" />Compare All</label>
+      </fieldset>
+    </section>
+    <section class="canvas-panel" aria-label="Graph panel">
+      <div class="canvas-wrapper">
+        <canvas id="graphCanvas"></canvas>
+        <div id="tooltip" role="tooltip" class="hidden"></div>
+      </div>
+      <div id="legend" class="legend hidden"></div>
+    </section>
+  </main>
+  <footer class="results" aria-label="Results">
+    <table>
+      <thead>
+        <tr><th>Method</th><th>Estimate</th><th>Error</th></tr>
+      </thead>
+      <tbody id="resultsBody"></tbody>
+    </table>
+    <div class="export">
+      <button id="pngBtn">Export PNG</button>
+      <button id="csvBtn">Export CSV</button>
+    </div>
+  </footer>
 </body>
 </html>
+

--- a/script.js
+++ b/script.js
@@ -1,131 +1,453 @@
-const canvas = document.getElementById("graphCanvas");
-const ctx = canvas.getContext("2d");
+const canvas = document.getElementById('graphCanvas');
+const ctx = canvas.getContext('2d');
+const dpr = window.devicePixelRatio || 1;
+const PADDING = 40;
 
-const funcInput = document.getElementById("funcInput");
-const aInput = document.getElementById("aInput");
-const bInput = document.getElementById("bInput");
-const nInput = document.getElementById("nInput");
-const showUpper = document.getElementById("showUpper");
-const showLower = document.getElementById("showLower");
+// UI elements
+const funcInput = document.getElementById('funcInput');
+const aInput = document.getElementById('aInput');
+const bInput = document.getElementById('bInput');
+const nInput = document.getElementById('nInput');
+const nLabel = document.getElementById('nLabel');
+const methodChecks = document.querySelectorAll('.methods input[type="checkbox"][value]');
+const compareAll = document.getElementById('compareAll');
+const themeToggle = document.getElementById('themeToggle');
+const resultsBody = document.getElementById('resultsBody');
+const legend = document.getElementById('legend');
+const alertBox = document.getElementById('alert');
+const tooltip = document.getElementById('tooltip');
+const pngBtn = document.getElementById('pngBtn');
+const csvBtn = document.getElementById('csvBtn');
 
-const leftSumEl = document.getElementById("leftSum");
-const rightSumEl = document.getElementById("rightSum");
-const midSumEl = document.getElementById("midSum");
-const upperSumEl = document.getElementById("upperSum");
-const lowerSumEl = document.getElementById("lowerSum");
+// State
+let a = parseFloat(aInput.value);
+let b = parseFloat(bInput.value);
+let n = parseInt(nInput.value);
+let rects = [];
+let dx = 0;
+let highlightIndex = null;
+let handlePos = { a: 0, b: 0 };
+let axisY = 0;
+let dragInfo = null;
+let lastDims = { width: 0, height: 0 };
 
-// Resize canvas
-function resizeCanvas() {
-  canvas.width = canvas.clientWidth;
-  canvas.height = canvas.clientHeight;
-}
-window.addEventListener("resize", () => {
-  resizeCanvas();
-  drawGraph();
-});
-resizeCanvas();
-
-// Safe function parser
+// Utility helpers
 function parseFunction(str) {
-  try {
-    return new Function("x", "return " + str);
-  } catch {
-    return () => NaN;
+  const ids = str.match(/[A-Za-z_][A-Za-z0-9_.]*/g) || [];
+  for (const id of ids) {
+    if (id === 'x') continue;
+    if (id.startsWith('Math.') && (id.slice(5) in Math)) continue;
+    throw new Error('Invalid identifier ' + id);
   }
+  return new Function('x', `with(Math){return ${str};}`);
 }
 
-// Calculate sums
-function calculateSums(f, a, b, n) {
+const SAMPLE_DENSITY = 16;
+function computeAll(f, a, b, n) {
   const dx = (b - a) / n;
-  let left = 0, right = 0, mid = 0;
-  let upper = 0, lower = 0;
-
-  let ys = [];
+  const rects = [];
+  const ys = [];
+  let yMin = 0, yMax = 0;
+  for (let i = 0; i <= n; i++) {
+    const x = a + dx * i;
+    const y = f(x);
+    ys.push(y);
+    if (y < yMin) yMin = y;
+    if (y > yMax) yMax = y;
+  }
+  let left = 0, right = 0, mid = 0, upper = 0, lower = 0, trapezoid = 0;
   for (let i = 0; i < n; i++) {
-    const x0 = a + i * dx;
-    const x1 = a + (i + 1) * dx;
-    const y0 = f(x0);
-    const y1 = f(x1);
-    const ym = f((x0 + x1) / 2);
-    ys.push(y0, y1, ym);
-
+    const x0 = a + dx * i;
+    const x1 = x0 + dx;
+    const y0 = ys[i];
+    const y1 = ys[i + 1];
+    const xm = (x0 + x1) / 2;
+    const ym = f(xm);
+    if (ym < yMin) yMin = ym;
+    if (ym > yMax) yMax = ym;
+    let ySup = Math.max(y0, y1, ym);
+    let yInf = Math.min(y0, y1, ym);
+    for (let k = 1; k < SAMPLE_DENSITY; k++) {
+      const xs = x0 + (k * dx) / SAMPLE_DENSITY;
+      const ysamp = f(xs);
+      if (ysamp > ySup) ySup = ysamp;
+      if (ysamp < yInf) yInf = ysamp;
+      if (ysamp > yMax) yMax = ysamp;
+      if (ysamp < yMin) yMin = ysamp;
+    }
     left += y0 * dx;
     right += y1 * dx;
     mid += ym * dx;
-    upper += Math.max(y0, y1) * dx;
-    lower += Math.min(y0, y1) * dx;
+    upper += ySup * dx;
+    lower += yInf * dx;
+    trapezoid += ((y0 + y1) / 2) * dx;
+    rects.push({ x0, x1, y0, y1, ym, ySup, yInf });
   }
-
-  const yMin = Math.min(...ys, 0);
-  const yMax = Math.max(...ys, 1);
-
-  return { left, right, mid, upper, lower, dx, yMin, yMax };
+  let simpson = 0;
+  const nEven = n % 2 === 0 ? n : n - 1;
+  for (let i = 0; i <= nEven; i++) {
+    const coeff = i === 0 || i === nEven ? 1 : i % 2 === 0 ? 2 : 4;
+    simpson += coeff * ys[i];
+  }
+  simpson *= dx / 3;
+  if (nEven !== n) {
+    simpson += ((ys[n - 1] + ys[n]) / 2) * dx;
+  }
+  return {
+    left,
+    right,
+    mid,
+    upper,
+    lower,
+    trapezoid,
+    simpson,
+    dx,
+    rects,
+    yMin: Math.min(yMin, 0),
+    yMax: Math.max(yMax, 0),
+  };
 }
 
-// Draw graph
-function drawGraph() {
-  ctx.clearRect(0, 0, canvas.width, canvas.height);
+function hexToRgba(hex, alpha) {
+  hex = hex.trim().replace('#', '');
+  if (hex.length === 3) hex = hex.split('').map(c => c + c).join('');
+  const num = parseInt(hex, 16);
+  const r = (num >> 16) & 255;
+  const g = (num >> 8) & 255;
+  const b = num & 255;
+  return `rgba(${r},${g},${b},${alpha})`;
+}
 
-  const f = parseFunction(funcInput.value);
-  const a = parseFloat(aInput.value);
-  const b = parseFloat(bInput.value);
-  const n = parseInt(nInput.value);
+function methodColor(method, alpha = 1) {
+  const color = getComputedStyle(document.documentElement).getPropertyValue(`--${method}`);
+  return alpha === 1 ? color.trim() : hexToRgba(color, alpha);
+}
 
-  if (isNaN(a) || isNaN(b) || isNaN(n) || n <= 0) return;
+function sampleFor(r, method) {
+  switch (method) {
+    case 'left':
+      return r.y0;
+    case 'right':
+      return r.y1;
+    case 'mid':
+      return r.ym;
+    case 'upper':
+      return r.ySup;
+    case 'lower':
+      return r.yInf;
+    default:
+      return 0;
+  }
+}
 
-  const { left, right, mid, upper, lower, dx, yMin, yMax } = calculateSums(f, a, b, n);
+function updateTable(res) {
+  const ref = res.simpson;
+  const rows = [
+    ['Left', res.left],
+    ['Right', res.right],
+    ['Midpoint', res.mid],
+    ['Upper', res.upper],
+    ['Lower', res.lower],
+    ['Trapezoidal', res.trapezoid],
+    ['Simpson', res.simpson],
+  ];
+  resultsBody.innerHTML = '';
+  for (const [name, val] of rows) {
+    const tr = document.createElement('tr');
+    const err = Math.abs(val - ref);
+    tr.innerHTML = `<td>${name}</td><td>${val.toFixed(6)}</td><td>${err.toFixed(6)}</td>`;
+    resultsBody.appendChild(tr);
+  }
+}
 
-  leftSumEl.textContent = left.toFixed(4);
-  rightSumEl.textContent = right.toFixed(4);
-  midSumEl.textContent = mid.toFixed(4);
-  upperSumEl.textContent = upper.toFixed(4);
-  lowerSumEl.textContent = lower.toFixed(4);
+function updateURL() {
+  const methods = Array.from(methodChecks)
+    .filter(ch => ch.checked)
+    .map(ch => ch.value)
+    .join('.');
+  const params = new URLSearchParams({
+    fx: funcInput.value,
+    a: aInput.value,
+    b: bInput.value,
+    n: nInput.value,
+    methods,
+    theme: document.body.classList.contains('dark') ? 'dark' : 'light',
+  });
+  history.replaceState(null, '', '?' + params.toString());
+}
 
-  const padding = 40;
-  const width = canvas.width - padding * 2;
-  const height = canvas.height - padding * 2;
+function loadFromURL() {
+  const params = new URLSearchParams(location.search);
+  if (params.get('fx')) funcInput.value = params.get('fx');
+  if (params.get('a')) aInput.value = params.get('a');
+  if (params.get('b')) bInput.value = params.get('b');
+  if (params.get('n')) {
+    nInput.value = params.get('n');
+    nLabel.textContent = params.get('n');
+  }
+  if (params.get('methods')) {
+    const ms = params.get('methods').split('.');
+    methodChecks.forEach(ch => {
+      ch.checked = ms.includes(ch.value);
+    });
+  }
+  if (params.get('theme') === 'dark') {
+    document.body.classList.add('dark');
+    themeToggle.textContent = '☀️';
+  }
+}
 
-  // Scale functions
-  const scaleX = (x) => padding + ((x - a) / (b - a)) * width;
-  const scaleY = (y) => padding + height - ((y - yMin) / (yMax - yMin)) * height;
+// Drawing
+let pending = false;
+function scheduleDraw() {
+  if (!pending) {
+    pending = true;
+    requestAnimationFrame(() => {
+      pending = false;
+      draw();
+    });
+  }
+}
 
-  // Draw rectangles
-  for (let i = 0; i < n; i++) {
-    const x0 = a + i * dx;
-    const x1 = a + (i + 1) * dx;
-    const y0 = f(x0);
-    const y1 = f(x1);
-
-    if (showUpper.checked) {
-      const yTop = Math.max(y0, y1);
-      ctx.fillStyle = "rgba(255,0,0,0.3)";
-      ctx.fillRect(scaleX(x0), scaleY(yTop), scaleX(x1)-scaleX(x0), scaleY(yMin)-scaleY(yTop));
-    }
-    if (showLower.checked) {
-      const yBottom = Math.min(y0, y1);
-      ctx.fillStyle = "rgba(0,0,255,0.3)";
-      ctx.fillRect(scaleX(x0), scaleY(yBottom), scaleX(x1)-scaleX(x0), scaleY(yMin)-scaleY(yBottom));
-    }
+function draw() {
+  a = parseFloat(aInput.value);
+  b = parseFloat(bInput.value);
+  n = parseInt(nInput.value);
+  nLabel.textContent = n;
+  const activeMethods = compareAll.checked
+    ? ['left', 'right', 'mid', 'upper', 'lower']
+    : Array.from(methodChecks)
+        .filter(ch => ch.checked)
+        .map(ch => ch.value);
+  let f;
+  try {
+    f = parseFunction(funcInput.value);
+    alertBox.style.display = 'none';
+  } catch (e) {
+    alertBox.textContent = 'Invalid function';
+    alertBox.style.display = 'block';
+    return;
+  }
+  if (!(b > a) || n < 1) {
+    alertBox.textContent = 'Check interval and partitions';
+    alertBox.style.display = 'block';
+    return;
   }
 
-  // Draw function curve
+  const res = computeAll(f, a, b, n);
+  rects = res.rects;
+  dx = res.dx;
+
+  const rect = canvas.getBoundingClientRect();
+  canvas.width = rect.width * dpr;
+  canvas.height = rect.height * dpr;
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  lastDims = { width: rect.width, height: rect.height };
+  ctx.clearRect(0, 0, rect.width, rect.height);
+
+  const width = rect.width - PADDING * 2;
+  const height = rect.height - PADDING * 2;
+  const scaleX = x => PADDING + ((x - a) / (b - a)) * width;
+  const scaleY = y => PADDING + height - ((y - res.yMin) / (res.yMax - res.yMin)) * height;
+  axisY = scaleY(0);
+  handlePos.a = scaleX(a);
+  handlePos.b = scaleX(b);
+
+  // Axes
+  ctx.strokeStyle = '#888';
+  ctx.lineWidth = 1;
   ctx.beginPath();
-  ctx.strokeStyle = "black";
+  ctx.moveTo(PADDING, axisY);
+  ctx.lineTo(PADDING + width, axisY);
+  ctx.moveTo(PADDING, PADDING);
+  ctx.lineTo(PADDING, PADDING + height);
+  ctx.stroke();
+
+  // Function curve
+  ctx.beginPath();
+  ctx.strokeStyle = getComputedStyle(document.documentElement).getPropertyValue('--fg');
   ctx.lineWidth = 2;
-  const steps = 500;
+  const steps = width;
   for (let i = 0; i <= steps; i++) {
     const x = a + ((b - a) * i) / steps;
     const y = f(x);
-    if (i === 0) ctx.moveTo(scaleX(x), scaleY(y));
-    else ctx.lineTo(scaleX(x), scaleY(y));
+    const px = scaleX(x);
+    const py = scaleY(y);
+    if (i === 0) ctx.moveTo(px, py);
+    else ctx.lineTo(px, py);
   }
   ctx.stroke();
+
+  // Rectangles
+  for (const method of activeMethods) {
+    ctx.fillStyle = methodColor(method, 0.4);
+    for (let i = 0; i < rects.length; i++) {
+      const r = rects[i];
+      const sample = sampleFor(r, method);
+      const x0 = scaleX(r.x0);
+      const w = scaleX(r.x1) - x0;
+      const y = scaleY(sample);
+      const base = scaleY(0);
+      ctx.fillRect(x0, Math.min(y, base), w, Math.abs(base - y));
+      if (highlightIndex === i) {
+        ctx.save();
+        ctx.strokeStyle = methodColor(method, 1);
+        ctx.lineWidth = 2;
+        ctx.strokeRect(x0, Math.min(y, base), w, Math.abs(base - y));
+        ctx.restore();
+      }
+    }
+  }
+
+  // Handles
+  ctx.fillStyle = getComputedStyle(document.documentElement).getPropertyValue('--accent');
+  ctx.fillRect(handlePos.a - 2, axisY - 8, 4, 16);
+  ctx.fillRect(handlePos.b - 2, axisY - 8, 4, 16);
+
+  updateTable(res);
+  updateLegend(activeMethods);
+  updateURL();
 }
 
-// Event listeners
-[funcInput, aInput, bInput, nInput, showUpper, showLower].forEach(el =>
-  el.addEventListener("input", drawGraph)
-);
+function updateLegend(methods) {
+  if (compareAll.checked || methods.length > 1) {
+    legend.classList.remove('hidden');
+    legend.innerHTML = '';
+    for (const m of methods) {
+      const span = document.createElement('span');
+      span.textContent = m;
+      span.style.color = methodColor(m, 1);
+      legend.appendChild(span);
+    }
+  } else {
+    legend.classList.add('hidden');
+  }
+}
 
-// Initial draw
-drawGraph();
+// Hover tooltip
+canvas.addEventListener('mousemove', e => {
+  if (!rects.length) return;
+  const x = e.offsetX;
+  const rel = (x - PADDING) / (lastDims.width - 2 * PADDING);
+  const idx = Math.floor(rel * n);
+  if (idx < 0 || idx >= rects.length) {
+    tooltip.classList.add('hidden');
+    highlightIndex = null;
+    scheduleDraw();
+    return;
+  }
+  highlightIndex = idx;
+  const r = rects[idx];
+  const methods = compareAll.checked
+    ? ['left', 'right', 'mid', 'upper', 'lower']
+    : Array.from(methodChecks)
+        .filter(ch => ch.checked)
+        .map(ch => ch.value);
+  let html = `[${r.x0.toFixed(3)}, ${r.x1.toFixed(3)}]`;
+  for (const m of methods) {
+    const sample = sampleFor(r, m);
+    const area = sample * dx;
+    html += `<br>${m}: f=${sample.toFixed(4)}, A=${area.toFixed(4)}`;
+  }
+  tooltip.innerHTML = html;
+  tooltip.style.left = `${x + 10}px`;
+  tooltip.style.top = `${e.offsetY + 10}px`;
+  tooltip.classList.remove('hidden');
+  scheduleDraw();
+});
+
+canvas.addEventListener('mouseleave', () => {
+  tooltip.classList.add('hidden');
+  highlightIndex = null;
+  scheduleDraw();
+});
+
+// Drag handles for a and b
+canvas.addEventListener('mousedown', e => {
+  const x = e.offsetX;
+  const y = e.offsetY;
+  if (Math.abs(x - handlePos.a) < 8 && Math.abs(y - axisY) < 20) {
+    dragInfo = { which: 'a', startA: a, startB: b };
+  } else if (Math.abs(x - handlePos.b) < 8 && Math.abs(y - axisY) < 20) {
+    dragInfo = { which: 'b', startA: a, startB: b };
+  }
+});
+
+window.addEventListener('mousemove', e => {
+  if (!dragInfo) return;
+  const bounds = canvas.getBoundingClientRect();
+  const rel = (e.clientX - bounds.left - PADDING) / (bounds.width - 2 * PADDING);
+  const val = dragInfo.startA + rel * (dragInfo.startB - dragInfo.startA);
+  if (dragInfo.which === 'a') {
+    a = Math.min(val, b - 0.001);
+    aInput.value = a.toFixed(3);
+  } else {
+    b = Math.max(val, a + 0.001);
+    bInput.value = b.toFixed(3);
+  }
+  scheduleDraw();
+});
+
+window.addEventListener('mouseup', () => {
+  if (dragInfo) {
+    dragInfo = null;
+    updateURL();
+  }
+});
+
+// Export buttons
+pngBtn.addEventListener('click', () => {
+  const link = document.createElement('a');
+  link.href = canvas.toDataURL('image/png');
+  link.download = 'riemann.png';
+  link.click();
+});
+
+csvBtn.addEventListener('click', () => {
+  if (!rects.length) return;
+  const rows = [
+    'i,x0,x1,leftSample,leftArea,rightSample,rightArea,midSample,midArea,upperSample,upperArea,lowerSample,lowerArea',
+  ];
+  rects.forEach((r, i) => {
+    rows.push([
+      i,
+      r.x0,
+      r.x1,
+      r.y0,
+      r.y0 * dx,
+      r.y1,
+      r.y1 * dx,
+      r.ym,
+      r.ym * dx,
+      r.ySup,
+      r.ySup * dx,
+      r.yInf,
+      r.yInf * dx,
+    ].map(v => Number(v).toFixed(6)).join(','));
+  });
+  const blob = new Blob([rows.join('\n')], { type: 'text/csv' });
+  const link = document.createElement('a');
+  link.href = URL.createObjectURL(blob);
+  link.download = 'riemann.csv';
+  link.click();
+});
+
+// Events
+[funcInput, aInput, bInput].forEach(el => el.addEventListener('input', scheduleDraw));
+nInput.addEventListener('input', () => {
+  nLabel.textContent = nInput.value;
+  scheduleDraw();
+});
+methodChecks.forEach(ch => ch.addEventListener('change', scheduleDraw));
+compareAll.addEventListener('change', scheduleDraw);
+themeToggle.addEventListener('click', () => {
+  document.body.classList.toggle('dark');
+  themeToggle.textContent = document.body.classList.contains('dark') ? '☀️' : '🌙';
+  scheduleDraw();
+  updateURL();
+});
+window.addEventListener('resize', scheduleDraw);
+
+loadFromURL();
+scheduleDraw();
+

--- a/style.css
+++ b/style.css
@@ -1,54 +1,192 @@
-body {
-  font-family: Arial, sans-serif;
-  margin: 20px;
-  background: #f0f0f0;
-  color: #333;
+:root {
+  --bg: #ffffff;
+  --fg: #222222;
+  --accent: #0095ff;
+  --grid: #cccccc;
+  --left: #1f77b4;
+  --right: #ff7f0e;
+  --mid: #2ca02c;
+  --upper: #d62728;
+  --lower: #9467bd;
+  --trap: #8c564b;
+  --simp: #e377c2;
 }
 
-h1 {
-  text-align: center;
+body.dark {
+  --bg: #1e1e1e;
+  --fg: #e0e0e0;
+  --grid: #555555;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: system-ui, Arial, sans-serif;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.app-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 1rem;
+  background: var(--accent);
+  color: #fff;
+}
+
+#themeToggle {
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 1.2rem;
+  cursor: pointer;
+}
+
+.alert {
+  padding: 0.5rem 1rem;
+  background: #ffdddd;
+  color: #a00;
+  display: none;
+}
+
+.layout {
+  flex: 1;
+  display: flex;
+  flex-direction: row;
+  min-height: 0;
 }
 
 .controls {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 15px;
-  justify-content: center;
-  margin-bottom: 20px;
+  width: 300px;
+  padding: 1rem;
+  overflow-y: auto;
+  background: var(--bg);
+  border-right: 1px solid var(--grid);
 }
 
-.controls label {
+.field {
   display: flex;
   flex-direction: column;
-  font-weight: bold;
-  font-size: 0.9rem;
+  margin-bottom: 1rem;
 }
 
-.controls input[type="text"],
-.controls input[type="number"] {
-  padding: 5px;
+.field input[type="text"],
+.field input[type="number"],
+.field input[type="range"] {
+  margin-top: 0.25rem;
+  padding: 0.25rem;
   font-size: 1rem;
-  width: 120px;
 }
 
-.graph-container {
+.methods {
   display: flex;
-  justify-content: center;
-  margin-bottom: 20px;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  border: 1px solid var(--grid);
+  padding: 0.5rem;
 }
 
-#graphCanvas {
-  border: 1px solid #333;
-  background: #fff;
-  max-width: 90vw;
-  height: 400px;
+.methods label {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
 }
 
-.sums-panel {
-  text-align: center;
-  font-size: 1rem;
+.canvas-panel {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 1rem;
+  min-width: 0;
 }
 
-.sums-panel h2 {
-  margin-bottom: 10px;
+.canvas-wrapper {
+  position: relative;
+  flex: 1;
+  min-height: 300px;
 }
+
+canvas {
+  width: 100%;
+  height: 100%;
+  background: var(--bg);
+  border: 1px solid var(--grid);
+  display: block;
+}
+
+#tooltip {
+  position: absolute;
+  pointer-events: none;
+  background: rgba(0,0,0,0.75);
+  color: #fff;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  white-space: nowrap;
+}
+
+.hidden { display: none; }
+
+.legend {
+  margin-top: 0.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.legend span {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.85rem;
+}
+
+.legend span::before {
+  content: "";
+  width: 12px;
+  height: 12px;
+  display: inline-block;
+  background: currentColor;
+}
+
+.results {
+  padding: 0.5rem 1rem 1rem;
+  background: var(--bg);
+  border-top: 1px solid var(--grid);
+}
+
+.results table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 0.5rem;
+}
+
+.results th,
+.results td {
+  border: 1px solid var(--grid);
+  padding: 0.25rem 0.5rem;
+  text-align: right;
+}
+
+.results th:first-child,
+.results td:first-child { text-align: left; }
+
+.export {
+  display: flex;
+  gap: 0.5rem;
+}
+
+@media (max-width: 700px) {
+  .layout {
+    flex-direction: column;
+  }
+  .controls {
+    width: 100%;
+    border-right: none;
+    border-bottom: 1px solid var(--grid);
+  }
+}
+


### PR DESCRIPTION
## Summary
- redesign UI with responsive controls, legend, and results table
- implement left/right/midpoint/upper/lower/trapezoidal/Simpson sums with tooltips and drag handles
- add export to PNG/CSV, theme toggle, and URL state sharing

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b569e257788329be83027287e168ac