### PR TITLE
Add interactive Riemann integral visualizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.next
+.DS_Store
+*.log

--- a/README.md
+++ b/README.md
@@ -1,0 +1,58 @@
+# Riemann Integral Visualizer
+
+Interactive web app to explore Riemann sums and numerical integration methods. Built with Next.js, React, D3 and Framer Motion.
+
+## Features
+- Function expression parsing with Math.js
+- Draggable interval endpoints and partition slider
+- Left, Right, Midpoint, Upper, Lower, Trapezoid and Simpson methods
+- Animated SVG plot with D3 and Framer Motion
+- Numeric dashboard comparing sums to a high accuracy reference integral
+- Export plot as PNG and table of rectangles as CSV
+- Shareable URL reflecting current settings
+- Light/Dark themes and accessible controls
+
+## Getting Started
+
+```bash
+npm install
+npm run dev
+```
+Visit `http://localhost:3000` in your browser.
+
+### Build for production
+```bash
+npm run build
+npm start
+```
+
+### Run tests
+```bash
+npm test
+```
+
+## Deployment
+
+### Vercel
+1. Push this repo to GitHub.
+2. On Vercel, create a new project from the repo.
+3. Build command: `npm run build`. Output directory: `out` (static export).
+
+### Netlify
+1. Push the repo to GitHub.
+2. Create a new Netlify site from the repo.
+3. Build command: `npm run build`. Publish directory: `out`.
+
+## Usage
+- Enter an expression like `sin(x)+1`, `x^2`, or `exp(-x*x)`.
+- Drag the red handles or edit numbers for interval `[a,b]`.
+- Adjust partition `n` with the slider or play button to animate.
+- Toggle methods in the legend to compare sums.
+- View numeric values and errors in the dashboard.
+- Use the export buttons to save the current view.
+
+## Tests
+Basic tests for Riemann sum utilities live in `tests/riemann.test.js` and run with Vitest.
+
+## License
+MIT

--- a/components/Controls.jsx
+++ b/components/Controls.jsx
@@ -1,0 +1,108 @@
+import React, { useState } from 'react';
+import { compileExpression } from '../utils/riemann';
+import { useTheme } from 'next-themes';
+
+export default function Controls({
+  expression,
+  setExpression,
+  a,
+  setA,
+  b,
+  setB,
+  n,
+  setN,
+  onPlay,
+  onExportPNG,
+  onExportCSV,
+}) {
+  const { theme, setTheme } = useTheme();
+  const [expr, setExpr] = useState(expression);
+  const [error, setError] = useState(null);
+
+  const handleExpr = (e) => {
+    const val = e.target.value;
+    setExpr(val);
+    const { error } = compileExpression(val);
+    setError(error ? error.message : null);
+    if (!error) setExpression(val);
+  };
+
+  const handleA = (e) => {
+    setA(parseFloat(e.target.value));
+  };
+  const handleB = (e) => {
+    setB(parseFloat(e.target.value));
+  };
+
+  const handleN = (e) => {
+    setN(parseInt(e.target.value, 10));
+  };
+
+  return (
+    <div className="controls">
+      <div>
+        <label>
+          Function f(x):
+          <input
+            type="text"
+            value={expr}
+            onChange={handleExpr}
+            aria-label="function expression"
+          />
+        </label>
+        {error && <span className="error">{error}</span>}
+      </div>
+      <div className="interval">
+        <label>
+          a:
+          <input
+            type="number"
+            value={a}
+            onChange={handleA}
+            aria-label="interval start a"
+          />
+        </label>
+        <label>
+          b:
+          <input
+            type="number"
+            value={b}
+            onChange={handleB}
+            aria-label="interval end b"
+          />
+        </label>
+      </div>
+      <div className="partition">
+        <label>
+          n:
+          <input
+            type="range"
+            min={1}
+            max={5000}
+            value={n}
+            onChange={handleN}
+            aria-label="number of partitions"
+          />
+          <input
+            type="number"
+            min={1}
+            max={5000}
+            value={n}
+            onChange={handleN}
+            aria-label="number of partitions input"
+          />
+        </label>
+        <button onClick={onPlay} aria-label="animate n">▶</button>
+      </div>
+      <div className="exports">
+        <button onClick={onExportPNG} aria-label="export png">Export PNG</button>
+        <button onClick={onExportCSV} aria-label="export csv">Export CSV</button>
+      </div>
+      <div className="theme-toggle">
+        <button onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')} aria-label="toggle theme">
+          {theme === 'light' ? 'Dark' : 'Light'} mode
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/Dashboard.jsx
+++ b/components/Dashboard.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+export default function Dashboard({ results }) {
+  if (!results) return null;
+  return (
+    <div className="dashboard">
+      {Object.entries(results).map(([method, data]) => {
+        if (method === 'reference') {
+          return (
+            <div key={method} className="result">
+              Reference integral: {data.toFixed(6)}
+            </div>
+          );
+        }
+        return (
+          <div key={method} className="result">
+            {method}: {data.sum.toFixed(6)} (error{' '}
+            {(data.sum - results.reference).toFixed(6)})
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/Legend.jsx
+++ b/components/Legend.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+export const METHOD_META = {
+  left: { color: '#1f77b4', label: 'Left' },
+  right: { color: '#ff7f0e', label: 'Right' },
+  midpoint: { color: '#2ca02c', label: 'Midpoint' },
+  trapezoid: { color: '#9467bd', label: 'Trapezoid' },
+  simpson: { color: '#8c564b', label: 'Simpson' },
+  upper: { color: '#e377c2', label: 'Upper' },
+  lower: { color: '#7f7f7f', label: 'Lower' },
+};
+
+export default function Legend({ methods, setMethods }) {
+  return (
+    <div className="legend">
+      {Object.entries(METHOD_META).map(([key, meta]) => (
+        <label key={key} style={{ color: meta.color }}>
+          <input
+            type="checkbox"
+            checked={methods[key]}
+            onChange={(e) => setMethods({ ...methods, [key]: e.target.checked })}
+            aria-label={`toggle ${meta.label} method`}
+          />
+          {meta.label}
+        </label>
+      ))}
+    </div>
+  );
+}

--- a/components/Plot.jsx
+++ b/components/Plot.jsx
@@ -1,0 +1,84 @@
+import React, { useEffect, useRef } from 'react';
+import { motion } from "framer-motion";
+import * as d3 from 'd3';
+import { METHOD_META } from './Legend';
+import { compileExpression, evaluateCompiled, computeAll } from '../utils/riemann';
+
+export default function Plot({ expression, a, b, n, methods, setA, setB, results, setResults }) {
+  const svgRef = useRef(null);
+  const workerRef = useRef(null);
+
+  useEffect(() => {
+    if (!workerRef.current) {
+      workerRef.current = new Worker(new URL('../workers/integral.worker.js', import.meta.url));
+      workerRef.current.onmessage = (e) => {
+        if (e.data.results) setResults(e.data.results);
+      };
+    }
+  }, [setResults]);
+
+  useEffect(() => {
+    const { compiled, error } = compileExpression(expression);
+    if (error) return;
+    if (n > 1000 && workerRef.current) {
+      workerRef.current.postMessage({ expr: expression, a, b, n, methods });
+    } else {
+      const res = computeAll(compiled, a, b, n, methods);
+      setResults(res);
+    }
+  }, [expression, a, b, n, methods, setResults]);
+
+  useEffect(() => {
+    const svg = d3.select(svgRef.current);
+    svg.selectAll('*').remove();
+    const width = 600;
+    const height = 400;
+    const margin = { top: 20, right: 20, bottom: 40, left: 40 };
+    svg.attr('viewBox', `0 0 ${width} ${height}`);
+    const plotWidth = width - margin.left - margin.right;
+    const plotHeight = height - margin.top - margin.bottom;
+    const g = svg.append('g').attr('transform', `translate(${margin.left},${margin.top})`);
+    const x = d3.scaleLinear().domain([a, b]).range([0, plotWidth]);
+    const { compiled } = compileExpression(expression);
+    const samples = d3.range(a, b, (b - a) / 1000).map((v) => [v, evaluateCompiled(compiled, v)]);
+    const yExtent = d3.extent(samples, (d) => d[1]);
+    const y = d3.scaleLinear().domain(yExtent).nice().range([plotHeight, 0]);
+    g.append('g').attr('transform', `translate(0,${plotHeight})`).call(d3.axisBottom(x));
+    g.append('g').call(d3.axisLeft(y));
+    const line = d3
+      .line()
+      .x((d) => x(d[0]))
+      .y((d) => y(d[1]));
+    g.append('path').datum(samples).attr('fill', 'none').attr('stroke', 'black').attr('stroke-width', 2).attr('d', line);
+    if (results) {
+      Object.keys(results).forEach((m) => {
+        if (m === 'reference') return;
+        const group = g.append('g').attr('fill', METHOD_META[m].color).attr('fill-opacity', 0.3).attr('stroke', METHOD_META[m].color);
+        results[m].rects.forEach((r) => {
+          group
+            .append('rect')
+            .attr('x', x(r.xLeft))
+            .attr('y', y(Math.max(0, r.height)))
+            .attr('width', x(r.xRight) - x(r.xLeft))
+            .attr('height', Math.abs(y(r.height) - y(0)));
+        });
+      });
+    }
+    const dragA = d3
+      .drag()
+      .on('drag', (event) => {
+        const newA = x.invert(event.x - margin.left);
+        if (newA < b) setA(newA);
+      });
+    const dragB = d3
+      .drag()
+      .on('drag', (event) => {
+        const newB = x.invert(event.x - margin.left);
+        if (newB > a) setB(newB);
+      });
+    g.append('circle').attr('cx', x(a)).attr('cy', y(0)).attr('r', 6).attr('fill', 'red').call(dragA).attr('tabindex', 0).attr('aria-label', 'drag start a');
+    g.append('circle').attr('cx', x(b)).attr('cy', y(0)).attr('r', 6).attr('fill', 'red').call(dragB).attr('tabindex', 0).attr('aria-label', 'drag end b');
+  }, [expression, a, b, n, results, setA, setB]);
+
+  return <motion.svg initial={{opacity:0}} animate={{opacity:1}} transition={{duration:0.5}} ref={svgRef} className="plot" role="img" aria-label="riemann plot" />;
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,7 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  output: 'export'
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "riemann-next",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "d3": "7.8.5",
+    "framer-motion": "10.16.4",
+    "mathjs": "11.8.0",
+    "html2canvas": "1.4.1",
+    "file-saver": "2.0.5",
+    "next-themes": "0.2.1"
+  },
+  "devDependencies": {
+    "vitest": "1.2.2"
+  }
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,0 +1,12 @@
+import '../styles/globals.css';
+import { ThemeProvider } from 'next-themes';
+
+function MyApp({ Component, pageProps }) {
+  return (
+    <ThemeProvider attribute="class" defaultTheme="light">
+      <Component {...pageProps} />
+    </ThemeProvider>
+  );
+}
+
+export default MyApp;

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,0 +1,117 @@
+import { useState, useEffect } from 'react';
+import Controls from '../components/Controls';
+import Plot from '../components/Plot';
+import Legend from '../components/Legend';
+import Dashboard from '../components/Dashboard';
+import html2canvas from 'html2canvas';
+import { saveAs } from 'file-saver';
+import { useRouter } from 'next/router';
+
+export default function Home() {
+  const router = useRouter();
+  const [expression, setExpression] = useState('sin(x)');
+  const [a, setA] = useState(0);
+  const [b, setB] = useState(Math.PI);
+  const [n, setN] = useState(10);
+  const [methods, setMethods] = useState({
+    left: true,
+    right: false,
+    midpoint: false,
+    trapezoid: false,
+    simpson: false,
+    upper: false,
+    lower: false,
+  });
+  const [results, setResults] = useState(null);
+
+  useEffect(() => {
+    if (!router.isReady) return;
+    const { f, a: qa, b: qb, n: qn, m } = router.query;
+    if (f) setExpression(f);
+    if (qa) setA(parseFloat(qa));
+    if (qb) setB(parseFloat(qb));
+    if (qn) setN(parseInt(qn, 10));
+    if (m) {
+      const copy = { ...methods };
+      Object.keys(copy).forEach((k) => (copy[k] = false));
+      m.split(',').forEach((k) => (copy[k] = true));
+      setMethods(copy);
+    }
+  }, [router.isReady]);
+
+  useEffect(() => {
+    const query = {
+      f: expression,
+      a: a.toFixed(3),
+      b: b.toFixed(3),
+      n,
+      m: Object.keys(methods)
+        .filter((k) => methods[k])
+        .join(','),
+    };
+    router.replace({ pathname: '/', query }, undefined, { shallow: true });
+  }, [expression, a, b, n, methods]);
+
+  const onExportPNG = async () => {
+    const canvas = await html2canvas(document.querySelector('.plot'));
+    canvas.toBlob((blob) => saveAs(blob, 'plot.png'));
+  };
+
+  const onExportCSV = () => {
+    if (!results) return;
+    let csv = 'method,x_left,x_right,sample_x,f(sample_x),area\n';
+    Object.entries(results).forEach(([m, data]) => {
+      if (m === 'reference') return;
+      data.rects.forEach((r) => {
+        csv += `${m},${r.xLeft},${r.xRight},${r.sample},${r.height},${r.area}\n`;
+      });
+    });
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    saveAs(blob, 'data.csv');
+  };
+
+  const onPlay = () => {
+    let i = n;
+    const timer = setInterval(() => {
+      i += 5;
+      if (i > 500) {
+        clearInterval(timer);
+        return;
+      }
+      setN(i);
+    }, 500);
+  };
+
+  return (
+    <main>
+      <h1>Riemann Integral Visualizer</h1>
+      <noscript>Please enable JavaScript to use the interactive features.</noscript>
+      <Controls
+        expression={expression}
+        setExpression={setExpression}
+        a={a}
+        setA={setA}
+        b={b}
+        setB={setB}
+        n={n}
+        setN={setN}
+        onPlay={onPlay}
+        onExportPNG={onExportPNG}
+        onExportCSV={onExportCSV}
+      />
+      <Plot
+        expression={expression}
+        a={a}
+        b={b}
+        n={n}
+        methods={methods}
+        setA={setA}
+        setB={setB}
+        results={results}
+        setResults={setResults}
+      />
+      <Legend methods={methods} setMethods={setMethods} />
+      <Dashboard results={results} />
+    </main>
+  );
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,46 @@
+html, body {
+  padding: 0;
+  margin: 0;
+  font-family: sans-serif;
+}
+body {
+  background: var(--bg);
+  color: var(--text);
+}
+:root {
+  --bg: #ffffff;
+  --text: #111111;
+}
+.dark {
+  --bg: #111111;
+  --text: #ffffff;
+}
+main {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+}
+.controls label {
+  margin-right: 1rem;
+}
+.legend {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+.plot {
+  max-width: 100%;
+  border: 1px solid #ccc;
+  touch-action: none;
+}
+.error {
+  color: red;
+  margin-left: 0.5rem;
+}
+@media (min-width: 768px) {
+  main {
+    flex-direction: row;
+    align-items: flex-start;
+  }
+}

--- a/tests/riemann.test.js
+++ b/tests/riemann.test.js
@@ -1,0 +1,14 @@
+import { compileExpression, riemannSum } from '../utils/riemann';
+import { test, expect } from 'vitest';
+
+test('left sum of x^2 approximates integral', () => {
+  const { compiled } = compileExpression('x^2');
+  const sum = riemannSum(compiled, 0, 1, 1000, 'left');
+  expect(sum).toBeCloseTo(1 / 3, 2);
+});
+
+test('trapezoid sum of x^2 approximates integral', () => {
+  const { compiled } = compileExpression('x^2');
+  const sum = riemannSum(compiled, 0, 1, 1000, 'trapezoid');
+  expect(sum).toBeCloseTo(1 / 3, 4);
+});

--- a/utils/riemann.js
+++ b/utils/riemann.js
@@ -1,0 +1,108 @@
+import { create, all } from 'mathjs';
+
+const math = create(all, {});
+
+export function compileExpression(expr) {
+  try {
+    const compiled = math.compile(expr);
+    return { compiled, error: null };
+  } catch (error) {
+    return { compiled: null, error };
+  }
+}
+
+export function evaluateCompiled(compiled, x) {
+  return compiled.evaluate({ x });
+}
+
+export function riemannRectangles(compiled, a, b, n, method) {
+  const dx = (b - a) / n;
+  const rects = [];
+  for (let i = 0; i < n; i++) {
+    const xLeft = a + i * dx;
+    const xRight = xLeft + dx;
+    let sample = xLeft;
+    switch (method) {
+      case 'right':
+        sample = xRight;
+        break;
+      case 'midpoint':
+        sample = (xLeft + xRight) / 2;
+        break;
+      case 'upper':
+        sample = evaluateCompiled(compiled, xLeft) > evaluateCompiled(compiled, xRight)
+          ? xLeft
+          : xRight;
+        break;
+      case 'lower':
+        sample = evaluateCompiled(compiled, xLeft) < evaluateCompiled(compiled, xRight)
+          ? xLeft
+          : xRight;
+        break;
+      case 'trapezoid':
+        sample = null; // handled separately
+        break;
+      case 'simpson':
+        sample = null; // handled separately
+        break;
+      default:
+        sample = xLeft;
+    }
+    let height;
+    if (method === 'trapezoid') {
+      const fLeft = evaluateCompiled(compiled, xLeft);
+      const fRight = evaluateCompiled(compiled, xRight);
+      height = (fLeft + fRight) / 2;
+      sample = (xLeft + xRight) / 2;
+    } else if (method === 'simpson') {
+      const fLeft = evaluateCompiled(compiled, xLeft);
+      const fRight = evaluateCompiled(compiled, xRight);
+      const fMid = evaluateCompiled(compiled, (xLeft + xRight) / 2);
+      height = (fLeft + 4 * fMid + fRight) / 6;
+      sample = (xLeft + xRight) / 2;
+    } else {
+      height = evaluateCompiled(compiled, sample);
+    }
+    rects.push({ xLeft, xRight, sample, height, area: height * dx });
+  }
+  return rects;
+}
+
+export function riemannSum(compiled, a, b, n, method) {
+  const rects = riemannRectangles(compiled, a, b, n, method);
+  return rects.reduce((acc, r) => acc + r.area, 0);
+}
+
+export function referenceIntegral(compiled, a, b) {
+  const N = 10000;
+  const dx = (b - a) / N;
+  let sum = 0;
+  for (let i = 0; i <= N; i++) {
+    const x = a + i * dx;
+    const weight = i === 0 || i === N ? 1 : i % 2 === 0 ? 2 : 4;
+    sum += weight * evaluateCompiled(compiled, x);
+  }
+  return (dx / 3) * sum;
+}
+
+export function computeAll(compiled, a, b, n, methods) {
+  const results = {};
+  Object.keys(methods).forEach((m) => {
+    if (methods[m]) {
+      const rects = riemannRectangles(compiled, a, b, n, m);
+      const sum = rects.reduce((s, r) => s + r.area, 0);
+      results[m] = { rects, sum };
+    }
+  });
+  const ref = referenceIntegral(compiled, a, b);
+  results.reference = ref;
+  return results;
+}
+
+export default {
+  compileExpression,
+  riemannRectangles,
+  riemannSum,
+  referenceIntegral,
+  computeAll,
+};

--- a/workers/integral.worker.js
+++ b/workers/integral.worker.js
@@ -1,0 +1,12 @@
+import { compileExpression, computeAll } from '../utils/riemann';
+
+self.onmessage = (e) => {
+  const { expr, a, b, n, methods } = e.data;
+  const { compiled, error } = compileExpression(expr);
+  if (error) {
+    self.postMessage({ error: error.message });
+    return;
+  }
+  const results = computeAll(compiled, a, b, n, methods);
+  self.postMessage({ results });
+};


### PR DESCRIPTION
## Summary
- build Next.js app that visualizes Riemann sums with D3 and Framer Motion
- add controls for function, interval, partition count and export options
- include numeric utilities and worker for heavy computations with tests

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/d3)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b570f2180c8329832067bc0660217a